### PR TITLE
Removed unloadable statements from all files.

### DIFF
--- a/app/controllers/issue_checklists_controller.rb
+++ b/app/controllers/issue_checklists_controller.rb
@@ -1,5 +1,4 @@
 class IssueChecklistsController < ApplicationController
-  unloadable
   
   before_filter :find_checklist_item
   

--- a/app/models/issue_checklist.rb
+++ b/app/models/issue_checklist.rb
@@ -1,5 +1,4 @@
 class IssueChecklist < ActiveRecord::Base
-  unloadable
   belongs_to :issue
   belongs_to :author, :class_name => "User", :foreign_key => "author_id"
   has_one :comment, :as => :commented, :dependent => :delete

--- a/lib/redmine_issue_checklist/patches/issue_patch.rb
+++ b/lib/redmine_issue_checklist/patches/issue_patch.rb
@@ -8,8 +8,6 @@ module RedmineIssueChecklist
       def self.included(base) # :nodoc:
         base.send(:include, InstanceMethods)
         base.class_eval do
-          unloadable # Send unloadable so it will not be unloaded in development
-
           alias_method_chain :copy_from, :checklist
           has_many :checklist, :class_name => "IssueChecklist", :dependent => :destroy
         end


### PR DESCRIPTION
This causes the rails autoloader to break in rails 4.2 and redmine >~3.1. Removing it appears to have no negative effects.

[More information about the issue](http://www.redmine.org/issues/20513)